### PR TITLE
Added Meta title and description

### DIFF
--- a/classes/page/fields.yaml
+++ b/classes/page/fields.yaml
@@ -43,6 +43,16 @@ tabs:
       type: checkbox
       comment: rainlab.pages::lang.editor.navigation_hidden_comment
 
+    viewBag[meta_title]:
+      tab: rainlab.pages::lang.editor.metas
+      label: rainlab.pages::lang.editor.meta_title
+
+    viewBag[meta_description]:
+      tab: rainlab.pages::lang.editor.metas
+      type: textarea
+      size: small
+      label: rainlab.pages::lang.editor.meta_description
+
 secondaryTabs:
   stretch: true
   fields:

--- a/components/StaticPage.php
+++ b/components/StaticPage.php
@@ -19,10 +19,15 @@ class StaticPage extends ComponentBase
     public $page;
 
     /**
-     * @var string The static page title
+     * @var string The static page meta title
      */
     public $title;
 
+    /**
+     * @var string The static page meta description
+     */
+    public $description;
+    
     /**
      * @var string The static page content
      */
@@ -47,7 +52,14 @@ class StaticPage extends ComponentBase
         $this->page = $this->page['page'] = $router->findByUrl($url);
 
         if ($this->page) {
-            $this->title = $this->page['title'] = $this->page->getViewBag()->property('title');
+            if ($this->page->getViewBag()->property('meta_title') == '')
+            {
+                $title = $this->page->getViewBag()->property('title');
+            } else {
+                $title = $this->page->getViewBag()->property('meta_title');
+            }
+            $this->title = $this->page['title'] = $title;
+            $this->description = $this->page['description'] = $this->page->getViewBag()->property('meta_description');
             $this->content = $this->page['content'] = $this->page->markup;
         }
     }

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -81,5 +81,8 @@ return [
         'hidden_comment' => 'Hidden pages are accessible only by logged-in back-end users.',
         'navigation_hidden' => 'Hide in navigation',
         'navigation_hidden_comment' => 'Check this box to hide this page from automatically generated menus and breadcrumbs.',
+        'metas' => 'Metas',
+        'meta_title' => 'Meta title',
+        'meta_description' => 'Meta description',
     ],
 ];


### PR DESCRIPTION
Hi,
in order to use the full power of Static pages I think it would be usefull to be able to edit meta title and descriptions of pages.

Page title is set from the meta title field if not empty, or from the page title.

Modifications includes localisation.

Use {{ staticPage.title }} and {{ staticPage.descipriton }} in themes.