### PR TITLE
Fixed backend page title

### DIFF
--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -72,7 +72,7 @@ class Index extends Controller
         $this->addCss('/plugins/rainlab/pages/assets/css/pages.css');
 
         $this->bodyClass = 'compact-container side-panel-not-fixed';
-        $this->pageTitle = 'rainlab.pages::lang.plugin_name';
+        $this->pageTitle = 'rainlab.pages::lang.plugin.name';
         $this->pageTitleTemplate = '%s Pages';
     }
 


### PR DESCRIPTION
[This commit](https://github.com/rainlab/pages-plugin/commit/99a25093464ff363c40051bfc65b1e8cd31b9fc2) changed the variable name of the plugin name, but the it was not changed in the `index.php` controller, which caused the page title to contain literally `rainlab.pages::lang.plugin_name`. This PR fixes this issue.