### PR TITLE
Allow extensibility of MenuItem fields

### DIFF
--- a/classes/Menu.php
+++ b/classes/Menu.php
@@ -141,8 +141,9 @@ class Menu extends CmsObject
 
             foreach ($items as $item) {
                 $parentReference = new MenuItemReference;
-                $parentReference->title = $item->title;
-                $parentReference->code = $item->code;
+                foreach ($item->basicProperties as $key) {
+                    $parentReference->{$key} = $item->{$key};
+                }
 
                 /*
                  * If the item type is URL, assign the reference the item's URL and compare the current URL with the item URL

--- a/classes/MenuItem.php
+++ b/classes/MenuItem.php
@@ -84,6 +84,19 @@ class MenuItem
         'replace'
     ];
 
+    public $basicProperties = [
+        'title',
+        'type',
+        'code'
+    ];
+
+    /**
+     * Extensible constructor
+     */
+    public function __construct() {
+        Event::fire('rainlab.pages.menuitem.create', [$this]);
+    }
+
     /**
      * Initializes a menu item from a data array. 
      * @param array $items Specifies the menu item data.

--- a/classes/Page.php
+++ b/classes/Page.php
@@ -394,10 +394,37 @@ class Page extends Content
             return [];
         }
 
-        $result = [];
         $bodyNode = $layout->getTwigNodeTree()->getNode('body')->getNode(0);
+        $nodes = $this->flattenTwigNode($bodyNode);
+        return $this->extractPlaceholderNodes($nodes);
+    }
 
-        foreach ($bodyNode as $node) {
+    /**
+     * Recursively flattens a twig node and children
+     * @param $node
+     * @return array A flat array of twig nodes
+     */
+    public function flattenTwigNode($node) {
+        $result = [];
+        if (!$node instanceof \Twig_Node) {
+            return $result;
+        }
+        foreach ($node as $subNode) {
+            $flatNodes = $this->flattenTwigNode($subNode);
+            $result = array_merge($result, [$subNode], $flatNodes);
+        }
+        return $result;
+    }
+
+    /**
+     * Extracts placeholder nodes from a flat list of nodes.
+     * @param $nodes
+     * @return array Returns an associative array of placeholder names, titles and types.
+     */
+    public function extractPlaceholderNodes($nodes)
+    {
+        $result = [];
+        foreach ($nodes as $node) {
             if (!$node instanceof \Cms\Twig\PlaceholderNode) {
                 continue;
             }

--- a/formwidgets/menuitems/assets/js/menu-items-editor.js
+++ b/formwidgets/menuitems/assets/js/menu-items-editor.js
@@ -275,11 +275,7 @@
         var self = this,
             data = {},
             propertyNames = this.$el.data('item-properties'),
-            basicProperties = {
-                'title': 1,
-                'type': 1,
-                'code': 1
-            },
+            basicProperties = this.$itemDataContainer.data('basic-properties'),
             typeInfoPropertyMap = {
                 reference: 'references',
                 replace: 'dynamicItems',

--- a/formwidgets/menuitems/partials/_item.htm
+++ b/formwidgets/menuitems/partials/_item.htm
@@ -5,6 +5,7 @@
     class="<?= $item->items ? 'has-subitems' : null ?>"
     data-status="<?= $groupStatus || !$item->items ? 'expanded' : 'collapsed' ?>"
     data-menu-item="<?= e(json_encode($item->toArray())) ?>"
+    data-basic-properties="<?= e(json_encode(array_combine($item->basicProperties, $item->basicProperties))) ?>"
 >
     <div>
         <a href="#" data-menu-item-link>


### PR DESCRIPTION
Hi All,

I needed to extend the MenuItem fields for a client. This is what I ended up needing to change in the pages-plugin. It's pretty minimal. I tried to get the client to enter strings into the 'code' field for menu items, but it was not ideal with the amount of confusion it caused.

For example, if I need to add a featured field to MenuItems I can use:

    public function boot()
    {
        Event::listen('rainlab.pages.menuitem.create', function ($obj) {
            $obj->featured = false;
            $obj->basicProperties[] = 'featured';
            $obj->fillable[] = 'featured';
        });

        Event::listen('backend.form.extendFields', function ($widget) {

            if (!$widget->getController() instanceof \RainLab\Pages\Controllers\Index ||
                !$widget->model instanceof \RainLab\Pages\Classes\MenuItem) {
                return;
            }

            $widget->addSecondaryTabFields([
                'featured' => [
                    'tab' => 'Display',
                    'label' => 'Featured',
                    'comment' => 'Mark this menu item as featured',
                    'type' => 'checkbox'
                ]
            ]);
        });
    }

If you have a better way of accomplishing the task, I'm all ears.
