### PR TITLE
Get correct parent page on pages nested deeper than 1 level

### DIFF
--- a/classes/PageList.php
+++ b/classes/PageList.php
@@ -100,7 +100,8 @@ class PageList
                     return true;
                 }
 
-                if ($iterator($subpages) == true) {
+                if ($iterator($subpages) == true && is_null($parent)) {
+
                     $parent = $fileName;
 
                     return true;


### PR DESCRIPTION
In trying to retrieve the parent page on pages nested more than 1 level deep, I found that the getPageParent routine would always bubble up to the topmost parent. This change fixes the routine so that the first parent page found is returned. Thanks. 