### PR TITLE
Add array support for repeaters

### DIFF
--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -399,7 +399,13 @@ class Index extends Controller
         $fields = $page->listLayoutSyntaxFields();
 
         foreach ($fields as $fieldCode => $fieldConfig) {
-            $formWidget->tabs['fields']['viewBag['.$fieldCode.']'] = $fieldConfig;
+            if ($fieldConfig['type'] == 'fileupload') continue;
+            
+            if ($fieldConfig['type'] == 'repeater') {
+                $fieldConfig['form']['tabs']['fields'] = array_get($fieldConfig, 'fields', []);
+                unset($fieldConfig['fields']);
+            }
+            $formWidget->tabs['fields']['viewBag[' . $fieldCode . ']'] = $fieldConfig;
         }
     }
 


### PR DESCRIPTION
Fixes issue with repeaters not working in Static pages.

Fileuploader is ignored but I will look into a possible solution around this when I have more time.