### PR TITLE
Better layout dropdown naming

### DIFF
--- a/classes/Page.php
+++ b/classes/Page.php
@@ -320,7 +320,7 @@ class Page extends Content
             }
 
             $baseName = $layout->getBaseFileName();
-            $result[$baseName] = strlen($layout->name) ? $layout->name : $baseName;
+            $result[$baseName] = strlen($layout->description) ? $layout->description : $baseName;
         }
 
         if (!$result) {


### PR DESCRIPTION
**Problem:** Users of pages plugin (client / end users) selecting layout by machine-name instead of human readable label.

**Fix:** show layout description

Screenshot before/after:

![rainlab-plugins-fix](https://cloud.githubusercontent.com/assets/374917/10652062/ae2f1cc6-7853-11e5-8178-74509c8e99e3.png)
