### PR TITLE
Allow for cssClass and code on resolveMenuItem

### DIFF
--- a/classes/Menu.php
+++ b/classes/Menu.php
@@ -179,6 +179,8 @@ class Menu extends CmsObject
                                         $reference->title = isset($item['title']) ? $item['title'] : '--no title--';
                                         $reference->url = isset($item['url']) ? $item['url'] : '#';
                                         $reference->isActive = isset($item['isActive']) ? $item['isActive'] : false;
+                                        $reference->viewBag['cssClass'] = isset($item['viewBag.cssClass']) ? $item['viewBag.cssClass'] : false;
+                                        $reference->viewBag['code'] = isset($item['viewBag.code']) ? $item['viewBag.code'] : false;
 
                                         if (!strlen($parentReference->url)) {
                                             $parentReference->url = $reference->url;


### PR DESCRIPTION
It would be great, if one could attach cssClass (and/or code) to MenuItems that are dynamically generated by a custom Plugin via the `pages.menuitem.resolveItem`-Event.

I understand `code` and `cssClass` should actually be under control of the Plugin user/developer, but otherwise there is no way, to attach e.g. classes to these dynamic Items, since they don't show up in the Menu editor of the PagesPlugin.