### PR TITLE
Allow for viewBag on `pages.menuitem.resolveItem`

### DIFF
--- a/classes/Menu.php
+++ b/classes/Menu.php
@@ -179,6 +179,7 @@ class Menu extends CmsObject
                                         $reference->title = isset($item['title']) ? $item['title'] : '--no title--';
                                         $reference->url = isset($item['url']) ? $item['url'] : '#';
                                         $reference->isActive = isset($item['isActive']) ? $item['isActive'] : false;
+                                        $reference->viewBag = isset($item['viewBag']) ? $item['viewBag'] : [];
 
                                         if (!strlen($parentReference->url)) {
                                             $parentReference->url = $reference->url;


### PR DESCRIPTION
Hi,
as you proposed in this comment
https://github.com/rainlab/pages-plugin/pull/119#issuecomment-186512850
control over the viewBag of menuItems to be resolved: would be perfect.
Maybe you can just merge this.
Best Regards