### PR TITLE
Update default.htm to use class variable in twig

### DIFF
--- a/components/staticmenu/default.htm
+++ b/components/staticmenu/default.htm
@@ -1,5 +1,5 @@
 {% if __SELF__.menuItems %}
-    <ul>
+    <ul class="{{ __SELF__.property('class') }}">
         {% partial __SELF__ ~ "::items" items=__SELF__.menuItems %}
     </ul>
 {% endif %}


### PR DESCRIPTION
Add the possibility to specify a class variable when user add the menu twig in page.

in the next example I use a bootstrap class to specify the menu in a in line list

<pre><code>{% component 'staticMenu' class='list-inline' %}</code></pre>