### PR TITLE
Keep cache content updated

### DIFF
--- a/classes/PageList.php
+++ b/classes/PageList.php
@@ -167,6 +167,8 @@ class PageList
         if (@File::put($filePath, $yamlData) === false) {
             throw new ApplicationException(Lang::get('cms::lang.cms_object.error_saving', ['name' => $filePath]));
         }
+
+        self::$configCache = $originalData;
     }
 
     /**
@@ -211,8 +213,6 @@ class PageList
     {
         $pagesConfig = $this->getPagesConfig();
         $requestedFileName = $page->getBaseFileName();
-
-        $tree = [];
 
         $iterator = function($configPages) use (&$iterator, &$pages, $requestedFileName) {
             $result = [];


### PR DESCRIPTION
**Problem:** When you delete two pages, from `meta/static-pages.yaml` disappear only one of them not both.

**Why:** Because we use same file content for each deletion (it is stored in the cache). So the first deletion updates the page hierarchy. Then the second deletion also updates the page hierarchy, but the original one, not the updated one.

**Solution:** Update cache content when we're updating file content.