### PR TITLE
Fix snippets sorting bug

### DIFF
--- a/widgets/SnippetList.php
+++ b/widgets/SnippetList.php
@@ -82,11 +82,9 @@ class SnippetList extends WidgetBase
             $snippets = $filteredSnippets;
         }
 
-        usort($snippets, function($a, $b) {
-            return strcmp($a->getName(), $b->getName());
-        });
-
-        return $snippets;
+        return collect($snippets)->sortBy(function($snippet) {
+            return $snippet->getName();
+        })->values();
     }
 
     protected function updateList()

--- a/widgets/SnippetList.php
+++ b/widgets/SnippetList.php
@@ -84,7 +84,7 @@ class SnippetList extends WidgetBase
 
         return collect($snippets)->sortBy(function($snippet) {
             return $snippet->getName();
-        })->values();
+        })->values()->all();
     }
 
     protected function updateList()


### PR DESCRIPTION
Lately I started getting the following error when editing static pages in the backend:

![image](https://cloud.githubusercontent.com/assets/6329543/22828006/27cadf1a-ef9b-11e6-8c34-8037fc0f4b45.png)

Seems like the ``$nippet->getName()`` changes the state of the object in some cases and as a result the ``usort()`` method fails. Using the Laravel's ``sortBy`` collection method fixes the problem. 