### PR TITLE
hide menu item if its not found

### DIFF
--- a/components/staticmenu/items.htm
+++ b/components/staticmenu/items.htm
@@ -4,10 +4,8 @@
             <a href="{{ item.url }}" {{ item.viewBag.isExternal ? 'target="_blank"' }}>
                 {{ item.title }}
             </a>
-        {% else %}
-            <span>{{ item.title }}</span>
         {% endif %}
-
+        
         {% if item.items %}
             <ul>{% partial __SELF__ ~ "::items" items=item.items %}</ul>
         {% endif %}

--- a/formwidgets/menuitems/partials/_item.htm
+++ b/formwidgets/menuitems/partials/_item.htm
@@ -1,11 +1,11 @@
 <?php
     $groupStatus = true;
 ?>
+<?php if (!strpos(e($this->getReferenceDescription($item)), 'Unnamed')): ?>
 <li
     class="<?= $item->items ? 'has-subitems' : null ?>"
     data-status="<?= $groupStatus || !$item->items ? 'expanded' : 'collapsed' ?>"
-    data-menu-item="<?= e(json_encode($item->toArray())) ?>"
->
+    data-menu-item="<?= e(json_encode($item->toArray())) ?>">
     <div>
         <a href="#" data-menu-item-link>
             <span class="title"><?= e($item->title) ?></span>
@@ -36,3 +36,4 @@
         <?php endif ?>
     </ol>
 </li>
+<?php endif ?>


### PR DESCRIPTION
incase you deleted a cms page,
- if no url , we dont display it in the view
- if the menu list item was `Unnamed` we dont display it