### PR TITLE
Add snippet to any tab not only secondary

### DIFF
--- a/assets/js/pages-snippets.js
+++ b/assets/js/pages-snippets.js
@@ -46,7 +46,7 @@
             return
         }
 
-        var $activeEditorTab = $('.control-tabs.secondary-tabs .tab-pane.active', $pageForm),
+        var $activeEditorTab = $('.tab-pane.active', $pageForm),
             $textarea = $activeEditorTab.find('[data-control="richeditor"] textarea'),
             $richeditorNode = $textarea.closest('[data-control="richeditor"]'),
             $snippetNode = $('<figure contenteditable="false" data-inspector-css-class="hero">&nbsp;</figure>'),


### PR DESCRIPTION
This let you add snippet to any tab of page. Only works if you move the main markup to new custom tab.

To do this will need to extend the page plugin:
```
        Event::listen('backend.form.extendFields', function($widget) {

            if (PluginManager::instance()->hasPlugin('RainLab.Pages') && $widget->model instanceof \RainLab\Pages\Classes\Page) {


                //move editor in it's own tab
                $primary = $widget->getTab('primary');
                $primary->stretch = true;
                $widget->removeField('markup');
                $widget->addTabFields([
                    'markup' => [
                        'type' => 'richeditor',
                        'size' => 'huge',
                        'stretch' => 'true',
                        'tab' => 'cms::lang.editor.content'
                    ]
                ]);
            }
        });

```