### PR TITLE
Fix translatable URLs

### DIFF
--- a/classes/Router.php
+++ b/classes/Router.php
@@ -1,5 +1,6 @@
 <?php namespace RainLab\Pages\Classes;
 
+use Lang;
 use Cache;
 use Config;
 use Cms\Classes\Theme;
@@ -148,7 +149,7 @@ class Router
      */
     protected function getCacheKey($keyName)
     {
-        return crc32($this->theme->getPath()).$keyName;
+        return crc32($this->theme->getPath()).$keyName.Lang::getLocale();
     }
 
     /**


### PR DESCRIPTION
If URL caching is enabled (cms.enableRoutesCache), URL translations don't work. Appending the current locale to the cache key fixes the problem.