### PR TITLE
Move display of custom page fields to secondary form tabs

### DIFF
--- a/assets/css/pages.css
+++ b/assets/css/pages.css
@@ -120,3 +120,7 @@
     background-size: 17px auto;
   }
 }
+.form-group.secondary-tab {
+    padding: 10px 20px;
+    background: #fff;
+}

--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -403,7 +403,8 @@ class Index extends Controller
                 unset($fieldConfig['fields']);
             }
 
-            $formWidget->tabs['fields']['viewBag[' . $fieldCode . ']'] = $fieldConfig;
+            $fieldConfig['cssClass'] = 'secondary-tab ' . array_get($fieldConfig, 'cssClass', '');
+            $formWidget->secondaryTabs['fields']['viewBag[' . $fieldCode . ']'] = $fieldConfig;
 
             /*
              * Translation support


### PR DESCRIPTION
As per discussion in #247, this moves custom page fields to the secondary tabs.  This is how we override the behavior in our custom plugin, and it works, but it would probably be ideal to be able to have a CSS class on the tab content to set padding and background color, as this way doesn't look quite right if there aren't enough fields to fill the tab.  So maybe it's something that should really be handled differently in core?