### PR TITLE
Allow page content field to be hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Include the Static Page [component](http://octobercms.com/docs/cms/components) t
 * `title` - specifies the static page title.
 * `content` - the static page content.
 
+If your layout does not need static page content entry, that section can be removed from the page form using the Inspector or manually with the `useContent` component property.
+
 ##### Static menus
 
 Add the staticMenu component to the static page layout to output a menu. The static menu component has the `code` property that should refer a code of a static menu the component should display. In the Inspector the `code` field is displayed as Menu. 

--- a/components/StaticPage.php
+++ b/components/StaticPage.php
@@ -40,6 +40,19 @@ class StaticPage extends ComponentBase
             'description' => 'rainlab.pages::lang.component.static_page_description'
         ];
     }
+    
+    public function defineProperties()
+    {
+        return [
+            'useContent' => [
+                'title'             => 'rainlab.pages::lang.component.static_page_use_content_name',
+                'description'       => 'rainlab.pages::lang.component.static_page_use_content_description',
+                'default'           => 1,
+                'type'              => 'checkbox',
+                'showExternalParam' => false
+            ]
+        ];
+    }
 
     public function onRun()
     {

--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -383,12 +383,25 @@ class Index extends Controller
 
         if ($type == 'page') {
             $widget->bindEvent('form.extendFieldsBefore', function() use ($widget, $object) {
+                $this->checkContentField($widget, $object);
                 $this->addPagePlaceholders($widget, $object);
                 $this->addPageSyntaxFields($widget, $object);
             });
         }
 
         return $widget;
+    }
+    
+    protected function checkContentField($formWidget, $page)
+    {
+        if (!($layout = $page->getLayoutObject())) {
+            return;
+        }
+        
+        $component = $layout->getComponent('staticPage');
+        if (!$component->property('useContent', true)) {
+            unset($formWidget->secondaryTabs['fields']['markup']);
+        }
     }
 
     protected function addPageSyntaxFields($formWidget, $page)

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -115,6 +115,8 @@ return [
     'component' => [
         'static_page_name' => 'Static page',
         'static_page_description' => 'Outputs a static page in a CMS layout.',
+        'static_page_use_content_name' => 'Use page content field',
+        'static_page_use_content_description' => 'If unchecked, the content section will not appear when editing the static page. Page content will be determined solely through placeholders and variables.',
         'static_menu_name' => 'Static menu',
         'static_menu_description' => 'Outputs a menu in a CMS layout.',
         'static_menu_code_name' => 'Menu',


### PR DESCRIPTION
This adds a component property named `useContent` that can be set to false to remove the content field from the page edit form.

I figure using an "affirmative" property name makes more sense than defining a negative like `noContent` or the `hideContentField` we've been using in our customization.