### PR TITLE
Add page picker form widget

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -104,6 +104,13 @@ class Plugin extends PluginBase
         ];
     }
 
+    public function registerFormWidgets()
+    {
+        return [
+            'RainLab\Pages\FormWidgets\PagePicker' => 'staticpagepicker'
+        ];
+    }
+
     public function boot()
     {
         Event::listen('cms.router.beforeRoute', function($url) {

--- a/README.md
+++ b/README.md
@@ -203,6 +203,17 @@ If you want to link to the static page by its URL, simply use the `|app` filter:
 
     <a href="{{ '/chairs'|app }}">Go to Chairs</a>
 
+##### Backend forms
+
+If you need to select from a list of static pages in your own backend forms, you can use the `staticpagepicker` widget:
+
+    fields:
+        field_name:
+            label: Static Page
+            type: staticpagepicker
+
+The field's assigned value will be the static page's file name, which can be used to link to the page as described above.
+
 ### Placeholders
 
 [Placeholders](http://octobercms.com/docs/cms/layouts#placeholders) defined in the layout are automatically detected by the Static Pages plugin. The Edit Static Page form displays a tab for each placeholder defined in the layout used by the page. Placeholders are defined in the layout in the usual way: 

--- a/formwidgets/PagePicker.php
+++ b/formwidgets/PagePicker.php
@@ -1,0 +1,64 @@
+<?php namespace RainLab\Pages\FormWidgets;
+
+use Backend\Classes\FormWidgetBase;
+use Cms\Classes\Theme;
+use RainLab\Pages\Classes\Page;
+
+/**
+ * Static page picker widget
+ *
+ * @package october\backend
+ * @author Alexey Bobkov, Samuel Georges
+ */
+class PagePicker extends FormWidgetBase
+{
+    protected $indent = '&nbsp;&nbsp;&nbsp;';
+
+    /**
+     * @inheritDoc
+     */
+    public function render()
+    {
+        $this->prepareVars();
+        return $this->makePartial('~/modules/backend/widgets/form/partials/_field_dropdown.htm');
+    }
+
+    /**
+     * Prepares the view data
+     */
+    public function prepareVars()
+    {
+        $this->vars['field'] = $this->makeFormField();
+    }
+
+    /**
+     * @return \Backend\Classes\FormField
+     */
+    protected function makeFormField()
+    {
+        $field = clone $this->formField;
+        $field->type = 'dropdown';
+
+        $tree = Page::buildMenuTree(Theme::getEditTheme());
+        $indent = $field->getConfig('indent', $this->indent);
+
+        // Flatten page tree for dropdown options
+        $options = [];
+        $iterator = function($items, $depth=0) use(&$iterator, &$tree, &$options, $indent) {
+
+            foreach ($items as $code) {
+                $itemData = $tree[$code];
+                $options[$code] = str_repeat($indent, $depth) . $itemData['title'];
+                if (!empty($itemData['items'])) {
+                    $iterator($itemData['items'], $depth+1);
+                }
+            }
+
+            return $options;
+        };
+
+        $field->options = $iterator($tree['--root-pages--']);
+
+        return $field;
+    }
+}


### PR DESCRIPTION
This should be pretty straightforward, though maybe there's a better way to do it.  This pull request adds a backend form widget ("staticpagepicker") for page selection, leveraging the caching from Page::buildMenuTree().  We wanted a way for end users to link content directly to pages without having to grab the URL, and it seemed like something with broader appeal.

#243 seems to apply here.