### PR TITLE
Handle empty layout file markup

### DIFF
--- a/classes/Page.php
+++ b/classes/Page.php
@@ -290,7 +290,7 @@ class Page extends ContentBase
 
         return Cms::url($url);
     }
-    
+
     /**
      * Determine the default layout for a new page
      * @param \RainLab\Pages\Classes\Page $parentPage
@@ -308,7 +308,7 @@ class Page extends ContentBase
                 return;
             }
         }
-        
+
         // Check theme layouts for one marked as the default
         foreach (Layout::listInTheme($this->theme) as $layout) {
             $component = $layout->getComponent('staticPage');
@@ -439,9 +439,9 @@ class Page extends ContentBase
             return [];
         }
 
-		if(!$layout->markup) {
-			return [];
-		}
+        if(!$layout->markup) {
+            return [];
+        }
 
         $syntax = SyntaxParser::parse($layout->markup, ['tagPrefix' => 'page:']);
         $result = $syntax->toEditor();
@@ -698,7 +698,7 @@ class Page extends ContentBase
      *   false if omitted.
      * - dynamicItems - Boolean value indicating whether the item type could generate new menu items.
      *   Optional, false if omitted.
-     * - cmsPages - a list of CMS pages (objects of the Cms\Classes\Page class), if the item type requires a CMS page reference to 
+     * - cmsPages - a list of CMS pages (objects of the Cms\Classes\Page class), if the item type requires a CMS page reference to
      *   resolve the item URL.
      * @param string $type Specifies the menu item type
      * @return array Returns an array
@@ -727,9 +727,9 @@ class Page extends ContentBase
      * - url - the menu item URL. Not required for menu item types that return all available records.
      *   The URL should be returned relative to the website root and include the subdirectory, if any.
      *   Use the Cms::url() helper to generate the URLs.
-     * - isActive - determines whether the menu item is active. Not required for menu item types that 
+     * - isActive - determines whether the menu item is active. Not required for menu item types that
      *   return all available records.
-     * - items - an array of arrays with the same keys (url, isActive, items) + the title key. 
+     * - items - an array of arrays with the same keys (url, isActive, items) + the title key.
      *   The items array should be added only if the $item's $nesting property value is TRUE.
      * @param \RainLab\Pages\Classes\MenuItem $item Specifies the menu item.
      * @param \Cms\Classes\Theme $theme Specifies the current theme.

--- a/classes/Page.php
+++ b/classes/Page.php
@@ -439,6 +439,10 @@ class Page extends ContentBase
             return [];
         }
 
+		if(!$layout->markup) {
+			return [];
+		}
+
         $syntax = SyntaxParser::parse($layout->markup, ['tagPrefix' => 'page:']);
         $result = $syntax->toEditor();
 


### PR DESCRIPTION
This PR adds an "empty layout markup" test before it is sent to Parser.

Combination of:
 * empty layout file with Static Page component
 * creating new Static Page (or editing one with empty layout assigned)

throws an error:

````
“Call to a member function getFields() on null" on line 92 of /Users/jan.vince/Web/october.dev/vendor/october/rain/src/Parse/Syntax/Parser.php
````