### PR TITLE
Fix getting breadcrumb pages urls

### DIFF
--- a/components/StaticBreadcrumbs.php
+++ b/components/StaticBreadcrumbs.php
@@ -37,7 +37,7 @@ class StaticBreadcrumbs extends ComponentBase
             $url = '/';
         }
 
-        $theme =Theme::getActiveTheme();
+        $theme = Theme::getActiveTheme();
         $router = new Router($theme);
         $page = $router->findByUrl($url);
 
@@ -61,7 +61,7 @@ class StaticBreadcrumbs extends ComponentBase
 
                 $reference = new MenuItemReference();
                 $reference->title = $pageInfo['title'];
-                $reference->url = Url::to($pageInfo['url']);
+                $reference->url = StaticPageClass::url($code);
                 $reference->isActive = $code == $startCode;
 
                 $breadcrumbs[] = $reference;


### PR DESCRIPTION
**Problem:** When using Translate plugin and also "Force URL schema" choice which means "Always prefix the URL with a language code.", I was getting breadcrumb URL without language code.

**Solution:** For getting page URL using the same function as `| staticPage` Twig filter.