### PR TITLE
Fix infinite loop possibility in breadcrumbs component

### DIFF
--- a/components/StaticBreadcrumbs.php
+++ b/components/StaticBreadcrumbs.php
@@ -49,7 +49,7 @@ class StaticBreadcrumbs extends ComponentBase
 
             while ($code) {
                 if (!isset($tree[$code])) {
-                    continue;
+                    break;
                 }
 
                 $pageInfo = $tree[$code];


### PR DESCRIPTION
This shouldn't be something that's encountered normally, but I ended up with a local project that triggered this infinite loop when a page was removed from the meta list but the page content file was retained (the change happened on a different machine, and a sync copied over the meta file change but isn't configured to delete anything).  So, the project state wasn't really valid, but an infinite loop is rarely the best way to deal with that. 😄 