### PR TITLE
Fix infinite loop

### DIFF
--- a/components/StaticBreadcrumbs.php
+++ b/components/StaticBreadcrumbs.php
@@ -49,7 +49,7 @@ class StaticBreadcrumbs extends ComponentBase
 
             while ($code) {
                 if (!isset($tree[$code])) {
-                    continue;
+                    break;
                 }
 
                 $pageInfo = $tree[$code];


### PR DESCRIPTION
Using ``continue`` creates an infinite loop, since nothing changes between iterations. I replaced it with ``break`` to fix the problem.