### PR TITLE
Fix menu item support for mediafinder

### DIFF
--- a/formwidgets/menuitems/assets/js/menu-items-editor.js
+++ b/formwidgets/menuitems/assets/js/menu-items-editor.js
@@ -189,6 +189,51 @@
                     var $input = $('[name="viewBag['+vbProperty+']"]', $popupContainer).not('[type=hidden]')
                     setPropertyOnElement($input, vbVal)
                 })
+
+                /**
+                 * Mediafinder support
+                 */
+                var mediafinderElements = $('[data-control="mediafinder"]');
+                var storageMediaPath = $('[data-storage-media-path]').data('storage-media-path');
+
+                $.each(mediafinderElements, function() {
+
+                      var input = $(this).find('>input');
+                      var propertyName = input.attr('name');
+
+                      if( propertyName.length ) {
+                          var propertyNameSimple = propertyName.substr(8).slice(0,-1);
+                      }
+
+                      var propertyValue = '';
+
+                      $.each(val, function(vbProperty, vbVal) {
+                          if( vbProperty == propertyNameSimple ) {
+                              propertyValue = vbVal;
+                          }
+                      });
+
+                      if( propertyValue != '' ) {
+
+                          $(this).toggleClass('is-populated');
+                          input.attr('value', propertyValue);
+
+                          var image = $(this).find('[data-find-image]');
+
+                          if( image.length ) {
+                              image.attr('src', storageMediaPath + propertyValue );
+                          }
+
+                          var file = $(this).find('[data-find-file-name]');
+
+                          if( file.length ) {
+                              file.text( propertyValue.substr(1) );
+                          }
+
+                      }
+
+                });
+
             }
             else {
                 var $input = $('[name="'+property+'"]', $popupContainer).not('[type=hidden]')

--- a/formwidgets/menuitems/partials/_menuitems.htm
+++ b/formwidgets/menuitems/partials/_menuitems.htm
@@ -3,6 +3,7 @@
     data-control="menu-item-editor"
     data-alias="<?= $this->alias ?>"
     data-item-properties="<?= e($itemProperties) ?>"
+    data-storage-media-path="<?= substr(Config::get('cms.storage.media.path'),0,1)=='/'? url(substr(Config::get('cms.storage.media.path'),1)) : url(substr(Config::get('cms.storage.media.path'))); ?>"
 >
     <div class="control-scrollbar" data-control="scrollbar">
         <div class="control-treeview treeview-light"


### PR DESCRIPTION
Fixed support for mediafinder when extending Menu item.

This fix issue #256.

When used like this in plugin:

````php
Event::listen('backend.form.extendFields', function ($widget) {

            if (!$widget->getController() instanceof \RainLab\Pages\Controllers\Index ||
                !$widget->model instanceof \RainLab\Pages\Classes\MenuItem) {
              return;
            }

            $widget->addTabFields([
              'viewBag[image]' => [
                'label' => ‘Image’,
                'type' => 'mediafinder',
                'mode' => 'image',
                'span' => 'full'
              ]
            ]);

});
````

will correctly show saved image on saved menu item with image.

*Previously no image was shown on saved and reopened menu items.*

![octobercms-pages-plugin-fix-mediafinder-in-menu-item](https://user-images.githubusercontent.com/1104383/30099792-13259010-92e7-11e7-8808-334f74d3d9ab.gif)