### PR TITLE
Allow HTML in Snippets

### DIFF
--- a/classes/Snippet.php
+++ b/classes/Snippet.php
@@ -471,7 +471,7 @@ class Snippet
         $map = [];
         $matches = [];
 
-        if (preg_match_all('/\<figure\s+[^\>]+\>[^\<]*\<\/figure\>/i', $markup, $matches)) {
+        if (preg_match_all('/\<figure\s+[^\>]+\>.*\<\/figure\>/i', $markup, $matches)) {
             foreach ($matches[0] as $snippetDeclaration) {
                 $nameMatch = [];
 


### PR DESCRIPTION
This PR allows for snippets to include HTML, which was previously filtered out for no apparent reason. This is really useful to allow for basic HTML tags.

@see https://github.com/rainlab/pages-plugin/issues/245