### PR TITLE
Perform raw urldecoding before comparing URLs, refactor compare logic

### DIFF
--- a/classes/Page.php
+++ b/classes/Page.php
@@ -677,6 +677,14 @@ class Page extends ContentBase
     }
 
     /**
+     * Returns whether the specified URLs are equal.
+     */
+    protected static function urlsAreEqual($url, $other)
+    {
+        return rawurldecode($url) === rawurldecode($other);
+    }
+
+    /**
      * Clears the menu item cache
      * @param \Cms\Classes\Theme $theme Specifies the current theme.
      */
@@ -750,7 +758,7 @@ class Page extends ContentBase
             $pageInfo = $tree[$item->reference];
             $result['url'] = Cms::url($pageInfo['url']);
             $result['mtime'] = $pageInfo['mtime'];
-            $result['isActive'] = $result['url'] == $url;
+            $result['isActive'] = self::urlsAreEqual($result['url'], $url);
         }
 
         if ($item->nesting || $item->type == 'all-static-pages') {
@@ -770,7 +778,7 @@ class Page extends ContentBase
 
                     $branchItem = [];
                     $branchItem['url'] = Cms::url($itemInfo['url']);
-                    $branchItem['isActive'] = $branchItem['url'] == $url;
+                    $branchItem['isActive'] = self::urlsAreEqual($branchItem['url'], $url);
                     $branchItem['title'] = $itemInfo['title'];
                     $branchItem['mtime'] = $itemInfo['mtime'];
 


### PR DESCRIPTION
This is intended to fix #261 by raw urldecoding the strings before performing any comparison.

The `rawurldecode` is used instead of `urldecode`, so that to ensure only percent-decoding is performed on the strings, without any additional operation (such as `+` signs being converted to `%20`).