### PR TITLE
remove custom field from layout

### DIFF
--- a/classes/Controller.php
+++ b/classes/Controller.php
@@ -107,6 +107,8 @@ class Controller
 
     public function parseSyntaxFields($content)
     {
+        $content = $this->removeCustomFields($content);
+
         try {
             return SyntaxParser::parse($content, [
                 'varPrefix' => 'extraData.',
@@ -116,5 +118,10 @@ class Controller
         catch (Exception $ex) {
             return $content;
         }
+    }
+
+    protected function removeCustomFields($content)
+    {
+        return preg_replace('/{variable[\s\S]*}{\/variable}|{repeater[\s\S]*{\/repeater}/', '', $content);
     }
 }


### PR DESCRIPTION
**The problem:**
When you add custom page fields on layouts:
```
{repeater name="slider" prompt="Add another slider" tab="Slider" placement="primary" }
{variable name="image" label="Image (Recommended 1920X1280, extension png or jpg.)" type="mediafinder" mode="image"}{/variable}
{variable name="title" label="Title" type="richeditor" toolbarButtons="bold|html"}{/variable}
{variable name="button" label="Button" type="richeditor" toolbarButtons="insertLink" size="small"}{/variable}
{/repeater}
{variable name="block1Title" tab="Block 1" label="Main Title" type="text" placement="primary" }{/variable}
{repeater name="block1" prompt="Add another" tab="Block 1" maxItems="4" placement="primary" }
{variable name="image" label="Image" type="mediafinder" mode="image"}{/variable}
{variable name="title" label="Title" type="text"}{/variable}
{variable name="description" label="Description" type="text"}{/variable}
{variable name="button" label="Button" type="richeditor" toolbarButtons="insertLink" size="small"}{/variable}
{/repeater}
{variable name="block2Title" tab="Block 2" label="Main Title" type="text" placement="primary" }{/variable}
{repeater name="block3" prompt="Add another" tab="Block 3" maxItems="5" placement="primary" }
{variable name="image" label="Image" type="mediafinder" mode="image"}{/variable}
{/repeater}
```
will print empty lines while create the cached file:
![page-layout](https://user-images.githubusercontent.com/12927166/33423574-edd59b02-d5c1-11e7-8659-1108dd94fb9c.png)

This pull request remove these fields from the layout before parse the content, and create the cashed file.
