### PR TITLE
Allow to set code property

### DIFF
--- a/classes/Menu.php
+++ b/classes/Menu.php
@@ -298,6 +298,7 @@ class Menu extends CmsObject
                                         $reference->url = isset($item['url']) ? $item['url'] : '#';
                                         $reference->isActive = isset($item['isActive']) ? $item['isActive'] : false;
                                         $reference->viewBag = isset($item['viewBag']) ? $item['viewBag'] : [];
+                                        $reference->code = isset($item['code']) ? $item['code'] : null;
 
                                         if (!strlen($parentReference->url)) {
                                             $parentReference->url = $reference->url;


### PR DESCRIPTION
This allows third party plugins, that manager menu types, to also set a code to correctly identify certain menu items later.