### PR TITLE
Firing references generated event

### DIFF
--- a/classes/Menu.php
+++ b/classes/Menu.php
@@ -365,7 +365,9 @@ class Menu extends CmsObject
         };
 
         $iterator($items);
-
+        
+        Event::fire('pages.menu.referencesGenerated', [&$items]);
+        
         return $items;
     }
 }


### PR DESCRIPTION
This allows third party plugins to manipulate static menu items. 