### PR TITLE
preset meta fields

### DIFF
--- a/classes/page/fields.yaml
+++ b/classes/page/fields.yaml
@@ -49,12 +49,16 @@ tabs:
         viewBag[meta_title]:
             tab: cms::lang.editor.meta
             label: cms::lang.editor.meta_title
+            preset:
+                field: viewBag[title]
 
         viewBag[meta_description]:
             tab: cms::lang.editor.meta
             label: cms::lang.editor.meta_description
             type: textarea
             size: tiny
+            preset:
+                field: viewBag[title]
 
 secondaryTabs:
     stretch: true


### PR DESCRIPTION
This improves SEO for the clients that forget to fill these two fields.