### PR TITLE
Fix repeater fields attribute

### DIFF
--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -430,7 +430,7 @@ class Index extends Controller
             if ($fieldConfig['type'] == 'fileupload') continue;
 
             if ($fieldConfig['type'] == 'repeater') {
-                $fieldConfig['form']['fields'] = array_get($fieldConfig, 'fields', []);
+                $fieldConfig['form']['fields'] = (array) $this->makeConfig(array_get($fieldConfig, 'fields', []));
                 unset($fieldConfig['fields']);
             }
 


### PR DESCRIPTION
This PR prevents `form` attribute from override and enables this syntax:
`{variable type="repeater" name="slider" prompt="Add slider section" tab="Slider" form="~/themes/xxx/config/slider.yaml"}{/variable}`
Previously fails with "_no fields found_", because within custom page repeater is nothing and `form` attribute was ignored.