### PR TITLE
Bug fix for file name in file system

### DIFF
--- a/classes/Page.php
+++ b/classes/Page.php
@@ -209,7 +209,7 @@ class Page extends ContentBase
     {
         $dir = rtrim($this->getFilePath(''), '/');
 
-        $fileName = trim(str_replace('/', '-', $this->getViewBag()->property('url')), '-');
+        $fileName = trim(str_slug(str_replace('/', '-', $this->getViewBag()->property('url'))), '-');
         if (strlen($fileName) > 200) {
             $fileName = substr($fileName, 0, 200);
         }


### PR DESCRIPTION
To stumble upon this error, it is enough to add .html to the url when creating the page, in filesystem page will be created with **.html.htm** at the end.