### PR TITLE
Support form attribute on repeater custom fields

### DIFF
--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -550,8 +550,10 @@ class Index extends Controller
             if ($fieldConfig['type'] == 'fileupload') continue;
 
             if ($fieldConfig['type'] == 'repeater') {
-                $fieldConfig['form']['fields'] = array_get($fieldConfig, 'fields', []);
-                unset($fieldConfig['fields']);
+                if (!is_string($fieldConfig['form'])) {
+                    $fieldConfig['form']['fields'] = array_get($fieldConfig, 'fields', []);
+                    unset($fieldConfig['fields']);
+                }
             }
 
             /*


### PR DESCRIPTION
This adds support for specifying the repeater's configuration as a path to a YAML file

{repeater form="~/themes/mytheme/meta/fields-customrepeater.yaml"}{/repeater}