### PR TITLE
Add support for filenames with periods

### DIFF
--- a/widgets/pagelist/partials/_treebranch.htm
+++ b/widgets/pagelist/partials/_treebranch.htm
@@ -1,6 +1,6 @@
 <?php foreach ($items as $pageObj): ?>
     <?php
-        $fileName = $pageObj->page->getBaseFileName();
+        $fileName = $pageObj->page->getFileName();
         $groupStatus = $this->getCollapseStatus($fileName);
         $dataId = $this->dataIdPrefix.'-'.$fileName;
         $searchMode = strlen($this->getSearchTerm()) > 0;


### PR DESCRIPTION
This adds support for pages with extra `.` characters in their filenames. Example: Creating a page with the URL of `/test.html` results in a file named `test.html.htm`. This should be supported because the final extension is still `.htm`. Fixes #416