### PR TITLE
Pass menu item data as JSON object

### DIFF
--- a/assets/js/pages-page.js
+++ b/assets/js/pages-page.js
@@ -550,7 +550,7 @@
             return result
         }
 
-        data.options.data['itemData'] = iterator($items)
+        data.options.data['itemData'] = JSON.stringify(iterator($items))
     }
 
     /*

--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -750,7 +750,7 @@ class Index extends Controller
                 $objectData['itemData'] = [];
             } else {
                 $objectData['itemData'] = json_decode($objectData['itemData'], true);
-                if (json_last_error() !== JSON_ERROR_NONE) {
+                if (json_last_error() !== JSON_ERROR_NONE || !is_array($objectData['itemData'])) {
                     $objectData['itemData'] = [];
                 }
             }

--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -59,19 +59,19 @@ class Index extends Controller
                     new PageList($this, 'pageList');
                     $this->vars['activeWidgets'][] = 'pageList';
                 }
-    
+
                 if ($this->user->hasAccess('rainlab.pages.manage_menus')) {
                     new MenuList($this, 'menuList');
                     $this->vars['activeWidgets'][] = 'menuList';
                 }
-    
+
                 if ($this->user->hasAccess('rainlab.pages.manage_content')) {
                     new TemplateList($this, 'contentList', function() {
                         return $this->getContentTemplateList();
                     });
                     $this->vars['activeWidgets'][] = 'contentList';
                 }
-    
+
                 if ($this->user->hasAccess('rainlab.pages.access_snippets')) {
                     new SnippetList($this, 'snippetList');
                     $this->vars['activeWidgets'][] = 'snippetList';
@@ -748,6 +748,11 @@ class Index extends Controller
             // If no item data is sent through POST, this means the menu is empty
             if (!isset($objectData['itemData'])) {
                 $objectData['itemData'] = [];
+            } else {
+                $objectData['itemData'] = json_decode($objectData['itemData'], true);
+                if (json_last_error() !== JSON_ERROR_NONE) {
+                    $objectData['itemData'] = [];
+                }
             }
         }
 


### PR DESCRIPTION
Instead of using normal post data, this translates the menu item data to a JSON string and sends through the data as a single data blob. This should circumvent issues with large menus and the PHP `max_input_vars` limit.

Fixes #422.