### PR TITLE
add configurable static layouts sorting

### DIFF
--- a/classes/Page.php
+++ b/classes/Page.php
@@ -379,7 +379,8 @@ class Page extends ContentBase
     public function getLayoutOptions()
     {
         $result = [];
-        $layouts = Layout::listInTheme($this->theme, true);
+        $sortKey = Config::get('rainlab.pages::layoutOptionsSortKey', 'created_at');
+        $layouts = Layout::listInTheme($this->theme, true)->sortBy($sortKey);
 
         foreach ($layouts as $layout) {
             if (!$layout->hasComponent('staticPage')) {

--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Sort key for the static layouts
+    |--------------------------------------------------------------------------
+    |
+    | What key should be used to sort the static layouts options
+    |
+    */
+    'layoutOptionsSortKey' => 'created_at',
+
+];


### PR DESCRIPTION
- Add config setting to choose key used to sort static layouts options (defaults to created_at to maintain current behavior)
- Fetch this setting and sort results based on that key