### PR TITLE
Allow model.beforeDelete to halt the deleting process

### DIFF
--- a/classes/Page.php
+++ b/classes/Page.php
@@ -244,18 +244,19 @@ class Page extends ContentBase
         foreach ($this->getChildren() as $subPage) {
             $result = array_merge($result, $subPage->delete());
         }
-
-        /*
-         * Remove from meta
-         */
-        $this->removeFromMeta();
-
+        
         /*
          * Delete the object
          */
         $result = array_merge($result, [$this->getBaseFileName()]);
 
         parent::delete();
+        
+        /*
+         * Remove from meta
+         */
+        $this->removeFromMeta();
+
 
         return $result;
     }


### PR DESCRIPTION
An exception thrown in model.beforeDelete should prevent the model from being deleted, but the current location of this code block would leave the page in a "half-deleted" state.