### PR TITLE
Add markdown and mediafinder to translatable syntax variables types

### DIFF
--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -611,7 +611,7 @@ class Index extends Controller
              * Translation support
              */
             $translatableTypes = ['text', 'textarea', 'richeditor', 'repeater', 'markdown', 'mediafinder'];
-            if (in_array($fieldConfig['type'], $translatableTypes)) {
+            if (in_array($fieldConfig['type'], $translatableTypes) && array_get($fieldConfig, 'translatable', true)) {
                 $page->translatable[] = 'viewBag['.$fieldCode.']';
             }
         }

--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -610,7 +610,7 @@ class Index extends Controller
             /*
              * Translation support
              */
-            $translatableTypes = ['text', 'textarea', 'richeditor', 'repeater'];
+            $translatableTypes = ['text', 'textarea', 'richeditor', 'repeater', 'markdown', 'mediafinder'];
             if (in_array($fieldConfig['type'], $translatableTypes)) {
                 $page->translatable[] = 'viewBag['.$fieldCode.']';
             }


### PR DESCRIPTION
Fixes https://github.com/rainlab/translate-plugin/issues/613
Fixes https://github.com/rainlab/translate-plugin/issues/614