### PR TITLE
Define real form inside code section of layout file

### DIFF
--- a/classes/Page.php
+++ b/classes/Page.php
@@ -969,6 +969,6 @@ class Page extends ContentBase
         $parser = new CodeParser($layout);
         $layout = $parser->source(null, null, null);
 
-        return collect($layout::defineForm());
+        return method_exists($layout, 'defineForm')) ? collect($layout::defineForm()) : null;
     }
 }

--- a/classes/Page.php
+++ b/classes/Page.php
@@ -22,6 +22,7 @@ use October\Rain\Parse\Bracket as TextParser;
 use October\Rain\Parse\Syntax\Parser as SyntaxParser;
 use ApplicationException;
 use Twig\Node\Node as TwigNode;
+use Cms\Classes\CodeParser;
 
 /**
  * Represents a static page.
@@ -958,5 +959,16 @@ class Page extends ContentBase
      */
     protected function checkSafeMode()
     {
+    }
+
+    public function layoutForm() {
+        if (!($layout = $this->getLayoutObject())) {
+            return;
+        }
+
+        $parser = new CodeParser($layout);
+        $layout = $parser->source(null, null, null);
+
+        return collect($layout::defineForm());
     }
 }

--- a/classes/Page.php
+++ b/classes/Page.php
@@ -969,6 +969,6 @@ class Page extends ContentBase
         $parser = new CodeParser($layout);
         $layout = $parser->source(null, null, null);
 
-        return method_exists($layout, 'defineForm')) ? collect($layout::defineForm()) : null;
+        return method_exists($layout, 'defineForm') ? collect($layout::defineForm()) : null;
     }
 }

--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -591,10 +591,29 @@ class Index extends Controller
                 $this->checkContentField($widget, $object);
                 $this->addPagePlaceholders($widget, $object);
                 $this->addPageSyntaxFields($widget, $object);
+                $this->addLayoutFormFields($widget, $object);
             });
         }
 
         return $widget;
+    }
+
+    protected function addLayoutFormFields($formWidget, $page) {
+        $form = $page->layoutForm();
+
+        if (is_null($form)) {
+            return;
+        }
+
+        $layoutFieldBag = $form->mapWithKeys(function($fieldConfig, $name) {
+            $fieldConfig['cssClass'] = 'secondary-tab ' . array_get($fieldConfig, 'cssClass', '');
+            return [ "viewBag[{$name}]" => $fieldConfig ];
+        })->toArray();
+
+        $formWidget->secondaryTabs['fields'] = array_merge(
+            $layoutFieldBag,
+            $formWidget->secondaryTabs['fields'],
+        );
     }
 
     protected function checkContentField($formWidget, $page)


### PR DESCRIPTION
Right now, the plugin lets you define ``{ variable }`` sections inside a layout which will be parsed by October. As I figured out, this is a native October CMS feature - not something that this plugin came up with.
However, I find it annoying that you cannot define a repeater field that way, e.g. for handling a grid of boxes where every box has a header, body and image field.
Also, defining variable sections inside of an actual html content looks kinda hacky to me.

This PR is using a different approach: Define the form of the layout inside a static method of the layout's code section. As this is a full form config array that's directly inserted into the page form field like any other content fields (e.g. placeholders), you'll get the full "form power" of October CMS back. Even repeater fields work.

As an example, a typical code section in your layout field could look like the following:

```php
<?php

static function defineForm() {
    return [
        'boxes' => [
            'type' => 'repeater',
            'form' => [
                'fields' => [
                    ['label' => 'Heading'],
                    ['label' => 'body', 'type' => 'textarea'],
                    ['label' => 'Image', 'type' => 'mediafinder']
                ]
            ]
        ]
    ];
}
```

A screenshot attached shows how this is showing up inside of the page form. This is then inserted as array elements in the view bag - which will be translated back to an array automatically which you can now loop over with twig.

Is this a good solution for the problem, or am I missing something here?

![21-06-30-00-11-41](https://user-images.githubusercontent.com/3300951/123874567-ad128480-d938-11eb-9205-eba99ed2bbbf.jpg)
