### PR TITLE
Add event to modify processed markup of a page

### DIFF
--- a/classes/Page.php
+++ b/classes/Page.php
@@ -601,6 +601,8 @@ class Page extends ContentBase
             $markup = TextParser::parse($markup, $globalVars);
         }
 
+        Event::fire('pages.page.markup', [&$markup]);
+
         return $this->processedMarkupCache = $markup;
     }
 


### PR DESCRIPTION
This is the one we need to modify the processed markup of a page, because we have some placeholders inside our page markup that should be rendered differently. It's actually a ``[[key]]`` pattern.