### PR TITLE
Add event hook for placeholder processing

### DIFF
--- a/classes/Page.php
+++ b/classes/Page.php
@@ -650,6 +650,11 @@ class Page extends ContentBase
         if (!empty($globalVars)) {
             $markup = TextParser::parse($markup, $globalVars);
         }
+        
+        /*
+         * Event hook
+         */
+        Event::fire('pages.page.getProcessedPlaceholderMarkup', [&$markup]);
 
         return $this->processedBlockMarkupCache[$placeholderName] = $markup;
     }


### PR DESCRIPTION
Would it be possible to also add an event hook for processing placeholders markup? There is already a similar event for processing page markup: https://github.com/rainlab/pages-plugin/blob/master/classes/Page.php#L626

So this change would unify the implementation of both methods and enable us to hook into placeholder processing as well.