### PR TITLE
Fix mediafinder in menus for October 2.x+

### DIFF
--- a/formwidgets/MenuItems.php
+++ b/formwidgets/MenuItems.php
@@ -171,4 +171,17 @@ class MenuItems extends FormWidgetBase
 
         return strlen($itemInfo) ? $itemInfo : trans('rainlab.pages::lang.menuitem.unnamed');
     }
+    
+    public function makeEditorTemplate()
+    {
+        $regEx = '#<script(.*?)</script>#is';
+        $partial = $this->makePartial('editorTemplate');
+
+        preg_match_all($regEx, $partial, $matches);
+
+        $scripts = implode('', $matches[0]);
+        $template = preg_replace($regEx, '', $partial);
+
+        return [$template, $scripts];
+    }
 }

--- a/formwidgets/menuitems/assets/js/menu-items-editor.js
+++ b/formwidgets/menuitems/assets/js/menu-items-editor.js
@@ -216,7 +216,7 @@
                 var storageMediaPath = $('[data-storage-media-path]').data('storage-media-path');
 
                 $.each(mediafinderElements, function() {
-                    var input = $(this).find('> input'),
+                    var input = $(this).find('input'),
                         propertyName = input.attr('name'),
                         propertyNameSimple;
 
@@ -242,7 +242,11 @@
                                 title: propertyValue.substring(1)
                             }];
 
-                            mediaFinder.addItems(items);
+                            var mediafinder = $(this).data('oc.mediaFinder');
+
+                            mediafinder.addItems(items);
+                            mediafinder.setValue();
+                            mediafinder.evalIsPopulated();
                         }
                         // v1 media finder
                         else {

--- a/formwidgets/menuitems/partials/_menuitems.htm
+++ b/formwidgets/menuitems/partials/_menuitems.htm
@@ -1,5 +1,6 @@
 <?php
     $mediaPath = Config::get('cms.storage.media.path', Config::get('system.storage.media.path', '/storage/app/media'));
+    list($editorTemplate, $editorScripts) = $this->makeEditorTemplate();
 ?>
 <div
     class="layout-absolute"
@@ -18,8 +19,10 @@
     </div>
 
     <script type="text/template" data-editor-template>
-        <?= $this->makePartial('editortemplate') ?>
+        <?= $editorTemplate ?>
     </script>
+    
+    <?= $editorScripts ?>
 
     <script type="text/template" data-item-template>
         <?= $this->makePartial('item', ['item' => $emptyItem]) ?>


### PR DESCRIPTION
This is my attempt to solve issue https://github.com/rainlab/pages-plugin/issues/509

My basic idea was to extract scripts from the editor template and output them separately, since they can't be nested into an existing template. Some javascript changes were also needed to correctly populate mediafinder elements in October 2.x+.

To test, you can use the following code which adds 2 mediafinder elements to the menu editor:

```php
Event::listen('backend.form.extendFields', function ($widget) {
    if (!$widget->getController() instanceof \RainLab\Pages\Controllers\Index) {
        return;
    }

    if (!$widget->model instanceof \RainLab\Pages\Classes\MenuItem) {
        return;
    }

    if ($widget->isNested) {
        return;
    }

    $widget->addTabFields([
        'viewBag[menuImage1]' => [
            'label' => 'Menu Image 1',
            'field' => 'viewBag[menuImage]',
            'type' => 'mediafinder',
            'mode' => 'image',
            'tab' => 'Media'
        ]
    ]);

    $widget->addTabFields([
        'viewBag[menuImage2]' => [
            'label' => 'Menu Image 2',
            'field' => 'viewBag[menuImage]',
            'type' => 'mediafinder',
            'mode' => 'image',
            'tab' => 'Media'
        ]
    ]);
});
```

There is however still one issue remaining - I couldn't get mediafinders with multiple items to work. I think some bigger changes would be needed for that. As I currently don't see a valid use case for such feature it is for now out of scope of this PR.