### PR TITLE
prevent nested nesters from getting too fancy

### DIFF
--- a/assets/js/pages-page.js
+++ b/assets/js/pages-page.js
@@ -230,6 +230,9 @@
         this.$pageTree.treeView('markActive', tabId)
         $('[data-control=filelist]', this.$sidePanel).fileList('markActive', tabId)
 
+        // Disable fancy layout on nested forms in repeater items
+        $('.field-repeater-item .form-tabless-fields', $tabPane).addClass('not-fancy');
+        
         var objectType = $('input[name=objectType]', $form).val()
         if (objectType.length > 0 &&
             (context.handler == 'onSave' || context.handler == 'onCommit' || context.handler == 'onReset')


### PR DESCRIPTION
Just a small thing, that is a bit irritating:
apply the not-fancy class for nested forms in repeater items in the ajaxSuccess handler.
This is basically the same as the plugin doesn when a tab is initialized.